### PR TITLE
Trim translated string

### DIFF
--- a/core/components/l10ntag/model/babelparser/babelparser.class.php
+++ b/core/components/l10ntag/model/babelparser/babelparser.class.php
@@ -43,7 +43,7 @@ class BabelParser {
 		$tagCulture = substr($tag,$this->tagStartLen,strpos($tag, " ")-$this->tagStartLen);
 		$cultureLen = strlen($tagCulture);
 		if($tagCulture == $this->cultureKey){
-			return substr($tag,$this->tagStartLen + $cultureLen,strlen($tag)-$this->tagStartLen - $this->tagEndLen-$cultureLen);
+			return trim(substr($tag,$this->tagStartLen + $cultureLen,strlen($tag)-$this->tagStartLen - $this->tagEndLen-$cultureLen));
 		}
 		else{
 			return "";


### PR DESCRIPTION
When using l10nTag on the title of an image inside [Gallery](https://docs.modx.com/extras/revo/gallery) plugin it returns:

`" my string"`

 The string should be trimmed.